### PR TITLE
fix null rendering and show errors

### DIFF
--- a/nerdlets/notebook-nerdlet/notebook-cell.js
+++ b/nerdlets/notebook-nerdlet/notebook-cell.js
@@ -82,7 +82,8 @@ export default class NotebookCell extends React.Component {
           setTimeout(() => {
             this.setState({
               jsonTreeLoading: false,
-              queryResponse: expandResponse(this.props.schema, query, variables, data)
+              queryResponse: expandResponse(this.props.schema, query, variables, data),
+              errors: errors
             })
           }, 0)
         })
@@ -176,7 +177,7 @@ export default class NotebookCell extends React.Component {
               sortObjectKeys={false}
               postprocessValue={treeHelpers.postprocessValue}
               valueRenderer={treeHelpers.valueRenderer}
-              isCustomNode={(node) => node.__custom && React.isValidElement(node.__custom)}
+              isCustomNode={(node) => node && node.__custom && React.isValidElement(node.__custom)}
               data={NodeRenderer.renderTree(this.state.queryResponse, {addCell: this.props.addCell})}
               theme={notebookJsonTreeStyling()}
               hideRoot={true}
@@ -184,8 +185,28 @@ export default class NotebookCell extends React.Component {
             />
           }
         </div>
+
+        {!this.state.jsonTreeLoading && this.state.errors ?
+          this.renderErrors() :
+          null
+        }
       </div>
     </div>
+  }
+
+  renderErrors() {
+    if (!this.state.errors) return null
+    return <>
+      <div className="cell-out-error">
+        Errors [{this.props.cellIndex}]
+       </div>
+      <JSONTree
+        data={this.state.errors}
+        theme={notebookJsonTreeStyling()}
+        hideRoot={true}
+        shouldExpandNode={() => true}
+      />
+    </>
   }
 }
 

--- a/nerdlets/notebook-nerdlet/results/augmentation.js
+++ b/nerdlets/notebook-nerdlet/results/augmentation.js
@@ -42,6 +42,7 @@ export function expandResponse(schema, query, _variables, root) {
 
 // TODO: Aliases aren't handled yet but that shouldn't be hard.
 function expandNode(parent, currentFieldName, node, path, typeMap, context) {
+  if (node == null) return null
   let typeName = node.__typename
   let type = typeMap[typeName]
   let fields = type.getFields()

--- a/nerdlets/notebook-nerdlet/styles.scss
+++ b/nerdlets/notebook-nerdlet/styles.scss
@@ -99,6 +99,11 @@
   color: $brand-400;
 }
 
+.cell-out-error {
+  @extend .cell-label;
+  color: $red-800;
+}
+
 .cell-out-value {
   margin: 14px;
   &> ul {


### PR DESCRIPTION
If errors exist we'll render the errors response in a JSON tree below the partial data.

<img width="801" alt="Screen Shot 2019-09-09 at 6 41 20 PM" src="https://user-images.githubusercontent.com/55462/64577537-8b927400-d331-11e9-9853-40ab6a3fcb03.png">


Closes #7 